### PR TITLE
Deterministically sets thread ids

### DIFF
--- a/android/src/main/java/com/rnthreads/JSThread.java
+++ b/android/src/main/java/com/rnthreads/JSThread.java
@@ -11,8 +11,8 @@ public class JSThread {
     private String jsSlugname;
     private ReactApplicationContext reactContext;
 
-    public JSThread(String jsSlugname) {
-        this.id = Math.abs(new Random().nextInt());
+    public JSThread(String jsSlugname, int id) {
+        this.id = id;
         this.jsSlugname = jsSlugname;
     }
 

--- a/android/src/main/java/com/rnthreads/RNThreadModule.java
+++ b/android/src/main/java/com/rnthreads/RNThreadModule.java
@@ -33,6 +33,7 @@ public class RNThreadModule extends ReactContextBaseJavaModule implements Lifecy
 
   private String TAG = "ThreadManager";
   private HashMap<Integer, JSThread> threads;
+  private int nextThreadId = 1;
 
   private ReactApplicationContext reactApplicationContext;
 
@@ -78,13 +79,14 @@ public class RNThreadModule extends ReactContextBaseJavaModule implements Lifecy
               .setReactInstanceManager(getReactInstanceManager())
               .setReactPackages(threadPackages);
 
-      JSThread thread = new JSThread(jsFileSlug);
+      int id = nextThreadId++;
+      JSThread thread = new JSThread(jsFileSlug, id);
       thread.runFromContext(
               getReactApplicationContext(),
               threadContextBuilder
       );
-      threads.put(thread.getThreadId(), thread);
-      promise.resolve(thread.getThreadId());
+      threads.put(id, thread);
+      promise.resolve(id);
     } catch (Exception e) {
       promise.reject(e);
       getDevSupportManager().handleException(e);

--- a/ios/ThreadManager.m
+++ b/ios/ThreadManager.m
@@ -6,6 +6,7 @@
 @synthesize bridge = _bridge;
 
 NSMutableDictionary *threads;
+int nextThreadId = 1;
 
 RCT_EXPORT_MODULE();
 
@@ -18,7 +19,7 @@ RCT_REMAP_METHOD(startThread,
     threads = [[NSMutableDictionary alloc] init];
   }
 
-  int threadId = abs(arc4random());
+  int threadId = nextThreadId++;
 
   NSURL *threadURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:name fallbackResource:name];
   NSLog(@"starting Thread %@", [threadURL absoluteString]);


### PR DESCRIPTION
I see no reason to randomise them and this prevents theoretical collisions with multiple threads (unless we will spawn/terminate `> sizeof(int)` in a single session)