### PR TITLE
Support thread messaging for any thread id

### DIFF
--- a/android/src/main/java/com/rnthreads/ThreadSelfModule.java
+++ b/android/src/main/java/com/rnthreads/ThreadSelfModule.java
@@ -32,6 +32,6 @@ public class ThreadSelfModule extends ReactContextBaseJavaModule {
         if (parentContext == null) { return; }
 
         parentContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit("Thread" + String.valueOf(threadId), data);
+                .emit("Thread", String.format("{\"id\":%d,\"message\":%s}", threadId, data));
     }
 }

--- a/ios/ThreadManager.m
+++ b/ios/ThreadManager.m
@@ -12,10 +12,11 @@
 NSMutableDictionary *threads;
 int nextThreadId = 1;
 NSString *const THREAD_TERMINATED = @"ThreadIsTerminated";
+NSString *const THREAD_MESSAGE = @"Thread";
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[THREAD_TERMINATED, @"Thread0", @"Thread1", @"Thread2", @"Thread3", @"Thread4"];
+  return @[THREAD_TERMINATED, THREAD_MESSAGE];
 }
 
 -(void)startObserving {
@@ -63,6 +64,7 @@ RCT_REMAP_METHOD(startThread,
   ThreadSelfManager *threadSelf = [threadBridge moduleForName:@"ThreadSelfManager"];
   [threadSelf setThreadId:threadId];
   [threadSelf setWorkerManager:self];
+  [threadSelf setThreadMessage:THREAD_MESSAGE];
 
 
   [threads setObject:threadBridge forKey:[NSNumber numberWithInt:threadId]];

--- a/ios/ThreadSelfManager.h
+++ b/ios/ThreadSelfManager.h
@@ -9,6 +9,7 @@
 @interface ThreadSelfManager : NSObject <RCTBridgeModule>
 @property int threadId;
 @property id workerManager;
+@property NSString *threadMessage;
 @end
 
 #endif

--- a/ios/WorkerSelfManager.m
+++ b/ios/WorkerSelfManager.m
@@ -8,6 +8,7 @@ RCT_EXPORT_MODULE();
 @synthesize bridge = _bridge;
 @synthesize workerManager = _workerManager;
 @synthesize threadId = _threadId;
+@synthesize threadMessage = _threadMessage;
 
 RCT_EXPORT_METHOD(postMessage: (NSString *)message)
 {
@@ -16,9 +17,9 @@ RCT_EXPORT_METHOD(postMessage: (NSString *)message)
     return;
   }
 
-  NSString *eventName = [NSString stringWithFormat:@"Thread%i", self.threadId];
+  NSString *eventBody = [NSString stringWithFormat:@"{\"id\":%i,\"message\":%@}", self.threadId, message];
 
-  [self.workerManager checkAndSendEvent:eventName body:message];
+  [self.workerManager checkAndSendEvent:self.threadMessage body:eventBody];
 }
 
 @end

--- a/js/Thread.js
+++ b/js/Thread.js
@@ -8,8 +8,8 @@ export default class Thread {
       throw new Error("Invalid path for thread. Only js files are supported");
     }
 
-    this.id = ThreadManager.startThread(jsPath.replace(".js", ""))
-      .then((id) => {
+    this.id = ThreadManager.startThread(jsPath.replace(".js", "")).then(
+      (id) => {
         DeviceEventEmitter.addListener(`Thread`, (msg) => {
           if (!msg) return;
           const { message, id: threadId } = JSON.parse(msg);
@@ -17,10 +17,8 @@ export default class Thread {
             this.onmessage(JSON.stringify(message));
         });
         return id;
-      })
-      .catch((err) => {
-        throw new Error(err);
-      });
+      }
+    );
   }
 
   postMessage(message) {

--- a/js/Thread.js
+++ b/js/Thread.js
@@ -1,28 +1,30 @@
-import {
-  NativeModules,
-  DeviceEventEmitter,
-} from 'react-native';
+import { NativeModules, DeviceEventEmitter } from "react-native";
 
 const { ThreadManager } = NativeModules;
 
 export default class Thread {
   constructor(jsPath) {
-    if (!jsPath || !jsPath.endsWith('.js')) {
-      throw new Error('Invalid path for thread. Only js files are supported');
+    if (!jsPath || !jsPath.endsWith(".js")) {
+      throw new Error("Invalid path for thread. Only js files are supported");
     }
 
     this.id = ThreadManager.startThread(jsPath.replace(".js", ""))
-      .then(id => {
-        DeviceEventEmitter.addListener(`Thread${id}`, (message) => {
-          !!message && this.onmessage && this.onmessage(message);
+      .then((id) => {
+        DeviceEventEmitter.addListener(`Thread`, (msg) => {
+          if (!msg) return;
+          const { message, id: threadId } = JSON.parse(msg);
+          if (id === threadId && this.onmessage)
+            this.onmessage(JSON.stringify(message));
         });
         return id;
       })
-      .catch(err => { throw new Error(err) });
+      .catch((err) => {
+        throw new Error(err);
+      });
   }
 
   postMessage(message) {
-    this.id.then(id => ThreadManager.postThreadMessage(id, message));
+    this.id.then((id) => ThreadManager.postThreadMessage(id, message));
   }
 
   terminate() {


### PR DESCRIPTION
Changes the rn thread event name from `Thread${id}` to `Thread` and passing the `id` in json. This allows us to pass any thread id in iOS (and we no longer have to hardcode them).

Allows unlimited reloads in the sim without crashing.