### PR TITLE
chore: Bump build:gradle to 2.3.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 


### PR DESCRIPTION
Bump gradle to `2.3.0` as maven doesn't seem to have `2.2.3` anymore

Thread:
https://exodusio.slack.com/archives/C04AZNR9LN6/p1723714262798019?thread_ts=1723709911.817519&cid=C04AZNR9LN6