### PR TITLE
fix: use NativeEventEmitter instead of DeviceEventEmitter

### DIFF
--- a/RNThread.podspec
+++ b/RNThread.podspec
@@ -10,9 +10,9 @@ Pod::Spec.new do |s|
     s.description    = "React native threads"
     s.license        = package['license']
     s.author         = package['author']
-    s.homepage       = "https://github.com/alexandrius/RNThread.git"
+    s.homepage       = "https://github.com/ExodusMovement/react-native-threads.git"
     s.platforms      = { :ios => "11.0" }
-    s.source         = { :git => "https://github.com/alexandrius/RNThread.git", :tag => "#{s.version}" }
+    s.source         = { :git => "https://github.com/ExodusMovement/react-native-threads.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"
 

--- a/js/Thread.js
+++ b/js/Thread.js
@@ -1,6 +1,7 @@
-import { NativeModules, DeviceEventEmitter } from "react-native";
+import { NativeModules, NativeEventEmitter } from "react-native";
 
 const { ThreadManager } = NativeModules;
+const emitter = new NativeEventEmitter(ThreadManager)
 
 export default class Thread {
   constructor(jsPath) {
@@ -10,7 +11,7 @@ export default class Thread {
 
     this.id = ThreadManager.startThread(jsPath.replace(".js", "")).then(
       (id) => {
-        DeviceEventEmitter.addListener(`Thread`, (msg) => {
+        emitter.addListener(`Thread`, (msg) => {
           if (!msg) return;
           const { message, id: threadId } = JSON.parse(msg);
           if (id === threadId && this.onmessage)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "/ios/RNThread.xcodeproj/project.pbxproj",
     "/ios/RNThread.xcodeproj/project.xcworkspace/!(xcuserdata)",
     "/js/",
-    "/index.js"
+    "/index.js",
+    "RNThread.podspec"
   ],
   "peerDependencies": {
     "react-native": ">=0.50.0"


### PR DESCRIPTION
DeviceEventEmitter is deprecated, and doesn't seem to work properly. Interestingly, it still works for ThreadSelfManager