### PR TITLE
fix: implement the `supportedEvents` handler

### DIFF
--- a/ios/ThreadsDevSettings.m
+++ b/ios/ThreadsDevSettings.m
@@ -10,6 +10,12 @@
   return @"RCTDevSettings";
 }
 
+// The RCTBridge requires us to implement this property, as without doing so dependents are prone to throwing an exception on startup.
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[];
+}
+
 // RCTDevSettings doesn't expose requiresMainQueueSetup, so we explicitly keep it in sync.
 + (BOOL)requiresMainQueueSetup
 {


### PR DESCRIPTION
### Description

The [`template-wallet`](https://github.com/ExodusMovement/template-wallet) app would encounter exceptions on startup related to a missing `supportedEvents` handler on [`ThreadsDevSettings`](https://github.com/ExodusMovement/react-native-threads/blob/exodus/ios/ThreadsDevSettings.m):

```
Exception 'You must override the `supportedEvents` method of ThreadsDevSettings' was thrown while invoking startThread on target ThreadManager with params (
    "./threads/sdk/index",
    24,
    25
)
```

This proposed change implements the missing handler.

### Further Context

https://github.com/ExodusMovement/template-wallet/issues/105
https://github.com/ExodusMovement/template-wallet/pull/110