### PR TITLE
add support for android multiprocessing

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,12 @@
 
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 
@@ -30,8 +31,8 @@ android {
 }
 
 repositories {
+    google()
     mavenCentral()
-    jcenter()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"

--- a/android/src/main/java/com/rnthreads/RNFileReaderPackage.java
+++ b/android/src/main/java/com/rnthreads/RNFileReaderPackage.java
@@ -1,0 +1,28 @@
+package com.rnthreads;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.modules.blob.FileReaderModule;
+
+public class RNFileReaderPackage implements ReactPackage {
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Arrays.<NativeModule>asList(
+            new FileReaderModule(reactContext)
+        );
+    }
+}

--- a/android/src/main/java/com/rnthreads/RNThreadModule.java
+++ b/android/src/main/java/com/rnthreads/RNThreadModule.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-
+import java.util.concurrent.TimeUnit;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -52,6 +52,10 @@ public class RNThreadModule extends ReactContextBaseJavaModule implements Lifecy
     this.additionalThreadPackages = additionalThreadPackages;
     reactContext.addLifecycleEventListener(this);
   }
+
+  // https://github.com/ExodusMovement/template-wallet/issues/106#issuecomment-2322604973
+  @ReactMethod public void addListener(String eventName) {}
+  @ReactMethod public void removeListeners(Integer count) {}
 
   @Override
   public String getName() {
@@ -222,7 +226,13 @@ public class RNThreadModule extends ReactContextBaseJavaModule implements Lifecy
   }
 
   private void downloadScriptToFileSync(String bundleUrl, String bundleOut) {
-    OkHttpClient client = new OkHttpClient();
+
+    // Here we increase the read timeout to avoid crashes on startup
+    // when bundling from an empty metro cache:
+    OkHttpClient client = new OkHttpClient.Builder()
+            .readTimeout(60, TimeUnit.SECONDS)
+            .build();
+
     final File out = new File(bundleOut);
 
     Request request = new Request.Builder()

--- a/android/src/main/java/com/rnthreads/RNThreadPackage.java
+++ b/android/src/main/java/com/rnthreads/RNThreadPackage.java
@@ -10,14 +10,32 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.rnthreads.RNFileReaderPackage;
+
 public class RNThreadPackage implements ReactPackage {
 
     private ReactNativeHost reactNativeHost;
     private ReactPackage additionalThreadPackages[];
 
-    public RNThreadPackage(ReactNativeHost reactNativeHost, ReactPackage... additionalThreadPackages) {
-        this.reactNativeHost = reactNativeHost;
-        this.additionalThreadPackages = additionalThreadPackages;
+    public RNThreadPackage(ReactNativeHost pReactNativeHost, ReactPackage ...pAdditionalThreadPackages) {
+        this.reactNativeHost = pReactNativeHost;
+
+        // You can add more packages here if you find that using some
+        // vanilla RN functionality leaves the background thread unable
+        // to mount properly.
+        ReactPackage[] extraPackages = {
+            new RNFileReaderPackage() /* https://github.com/facebook/react-native/blob/7ea7d946c643f076c29bcf11b927f7569e3c516f/Libraries/Core/setUpXHR.js#L31 */
+            // ...
+        };
+
+        // Create an array large enough to acommodate for both
+        // the user-defined `pAdditionalThreadPackages` and the
+        // `extraPackages`:
+        this.additionalThreadPackages = new ReactPackage[pAdditionalThreadPackages.length + extraPackages.length];
+
+        // i.e. [...pAdditionalThreadPackages, ...extraPackages];
+        System.arraycopy(pAdditionalThreadPackages, 0, this.additionalThreadPackages, 0, pAdditionalThreadPackages.length);
+        System.arraycopy(extraPackages, 0, this.additionalThreadPackages, pAdditionalThreadPackages.length, extraPackages.length);
     }
 
     @Override

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-threads",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Adds fixes and enhancements for [bugs encountered](https://github.com/ExodusMovement/template-wallet/issues/106) when trying to run on Android in `react-native@0.71.11`:

- Makes React Native's `FileReader` `NativeModule` available in threaded context.
- Increases default timeout when bundling to avoid crashes.
- Bump to `0.3.8`.

These changes were tested in: https://github.com/ExodusMovement/template-wallet/pull/113